### PR TITLE
 Don't show alternative hrefs if product/category is not active in that store

### DIFF
--- a/HrefLang/HrefLangValueProvider.php
+++ b/HrefLang/HrefLangValueProvider.php
@@ -29,10 +29,17 @@ class HrefLangValueProvider
     public function getValue(Store $store): string
     {
         $localeCode = $this->scopeConfig->getValue(
-            \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE,
+            'general/locale/code_for_hreflang',
             $this->localeConfigScope,
             $this->getScopeCode($store)
         );
+        if (!$localeCode) {
+            $localeCode = $this->scopeConfig->getValue(
+                \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE,
+                $this->localeConfigScope,
+                $this->getScopeCode($store)
+            );
+        }
         return strtolower(str_replace('_', '-', $localeCode));
     }
 

--- a/HrefLang/HrefLangValueProvider.php
+++ b/HrefLang/HrefLangValueProvider.php
@@ -9,6 +9,8 @@ use Magento\Store\Model\Store;
 
 class HrefLangValueProvider
 {
+    const XML_PATH_LOCALE_FOR_HREFLANG = 'general/locale/code_for_hreflang';
+
     /**
      * @var ScopeConfigInterface
      */
@@ -29,7 +31,7 @@ class HrefLangValueProvider
     public function getValue(Store $store): string
     {
         $localeCode = $this->scopeConfig->getValue(
-            'general/locale/code_for_hreflang',
+            self::XML_PATH_LOCALE_FOR_HREFLANG,
             $this->localeConfigScope,
             $this->getScopeCode($store)
         );

--- a/HrefLang/Model/Source/Locale.php
+++ b/HrefLang/Model/Source/Locale.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brandung\Seo\HrefLang\Model\Source;
+
+class Locale extends \Magento\Config\Model\Config\Source\Locale
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $options = [['value' => '', 'label' => '']];
+        foreach (parent::toOptionArray() as $option) {
+            $options[] = [
+                'value' => $option['value'],
+                'label' => strtolower(str_replace('_', '-', $option['value']))
+            ];
+        }
+        usort(
+            $options,
+            function ($a, $b) {
+                return $a['label'] <=> $b['label'];
+            }
+         );
+
+        return $options;
+    }
+}

--- a/HrefLang/StoreUrlRetriever/CmsPageStoreUrl.php
+++ b/HrefLang/StoreUrlRetriever/CmsPageStoreUrl.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 namespace Brandung\Seo\HrefLang\StoreUrlRetriever;
 
 use Magento\Cms\Api\PageRepositoryInterface;
+use Magento\Cms\Helper\Page as PageHelper;
+use Magento\Cms\Model\Page;
 use Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\Store;
 use Magento\Cms\Model\ResourceModel\Page as PageResource;
+use Magento\Cms\Model\ResourceModel\Page\Collection as PageCollection;
+use Magento\Cms\Model\ResourceModel\Page\CollectionFactory as PageCollectionFactory;
 
 class CmsPageStoreUrl implements StoreUrlInterface
 {
@@ -23,15 +28,27 @@ class CmsPageStoreUrl implements StoreUrlInterface
      * @var PageResource
      */
     private $pageResource;
+    /**
+     * @var PageCollectionFactory
+     */
+    private $pageCollectionFactory;
+    /**
+     * @var PageHelper
+     */
+    private $pageHelper;
 
     public function __construct(
         PageRepositoryInterface $pageRepository,
         CmsPageUrlPathGenerator $urlPathGenerator,
-        PageResource $pageResource
+        PageResource $pageResource,
+        PageCollectionFactory $pageCollectionFactory,
+        PageHelper $pageHelper
     ) {
         $this->pageRepository = $pageRepository;
         $this->urlPathGenerator = $urlPathGenerator;
         $this->pageResource = $pageResource;
+        $this->pageCollectionFactory = $pageCollectionFactory;
+        $this->pageHelper = $pageHelper;
     }
 
     /**
@@ -44,9 +61,36 @@ class CmsPageStoreUrl implements StoreUrlInterface
     public function getUrl(int $entityId, Store $store): string
     {
         $page = $this->pageRepository->getById($entityId);
-        $pageId = $this->pageResource->checkIdentifier($page->getIdentifier(), $store->getId());
-        $storePage = $this->pageRepository->getById($pageId);
+        try {
+            $storePage = $this->getPageByGlobalIdentifier((string)$page->getData('global_identifier'), $store);
+        } catch (NoSuchEntityException $e) {
+            $pageId = $this->pageResource->checkIdentifier($page->getIdentifier(), $store->getId());
+            $storePage = $this->pageRepository->getById($pageId);
+        }
+
         $path = $this->urlPathGenerator->getUrlPath($storePage);
         return $store->getBaseUrl() . $path;
+    }
+
+    public function getPageByGlobalIdentifier(string $globalIdentifier, Store $store): Page
+    {
+        if (!$globalIdentifier) {
+            throw new NoSuchEntityException(__('No global identifier given'));
+        }
+
+        /** @var PageCollection $pageCollection */
+        $pageCollection = $this->pageCollectionFactory->create();
+        $pageCollection->addStoreFilter($store);
+        $pageCollection->addFieldToFilter('global_identifier', $globalIdentifier);
+
+        $page = $pageCollection->getFirstItem();
+        if (!$page->getId()) {
+            throw new NoSuchEntityException(__(
+                'No Page with global identifier "%1" in store %2.',
+                $globalIdentifier,
+                $store->getCode()
+            ));
+        }
+        return $page;
     }
 }

--- a/HrefLang/StoreUrlRetriever/CmsPageStoreUrl.php
+++ b/HrefLang/StoreUrlRetriever/CmsPageStoreUrl.php
@@ -72,6 +72,12 @@ class CmsPageStoreUrl implements StoreUrlInterface
         return $store->getBaseUrl() . $path;
     }
 
+    /**
+     * @param string $globalIdentifier
+     * @param Store $store
+     * @return Page
+     * @throws NoSuchEntityException
+     */
     public function getPageByGlobalIdentifier(string $globalIdentifier, Store $store): Page
     {
         if (!$globalIdentifier) {

--- a/HrefLang/UrlAlternativesProvider/AbstractUrlAlternativesProvider.php
+++ b/HrefLang/UrlAlternativesProvider/AbstractUrlAlternativesProvider.php
@@ -56,9 +56,13 @@ abstract class AbstractUrlAlternativesProvider implements UrlAlternativesProvide
      */
     public function getAlternatives(): array
     {
-        return array_map(function (Store $store) {
-            return $this->getAlternativeForStore($store);
-        }, $this->alternativeStoreProvider->getAlternativeStores());
+        return array_filter(array_map(function (Store $store) {
+            try {
+                return $this->getAlternativeForStore($store);
+            } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+                return false;
+            }
+        }, $this->alternativeStoreProvider->getAlternativeStores()));
     }
 
     /**

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Brandung\Seo\Setup;
+
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @param SchemaSetupInterface $setup
+     * @param ModuleContextInterface $context
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        if (version_compare($context->getVersion(), '1.1.0') < 0) {
+            $connection = $setup->getConnection();
+            $connection->addColumn(
+                $connection->getTableName('cms_page'),
+                'global_identifier',
+                [
+                    Table::OPTION_TYPE     => Table::TYPE_TEXT,
+                    Table::OPTION_LENGTH   => '255',
+                    Table::OPTION_NULLABLE => true,
+                    'comment'              => 'Global CMS Identifier',
+                ]
+            );
+        }
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="general">
+            <group id="locale">
+                <field id="code_for_hreflang" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Locale Code for hreflang Tags</label>
+                    <source_model>Brandung\Seo\HrefLang\Model\Source\Locale</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Brandung_Seo" setup_version="1.0.0">
+    <module name="Brandung_Seo" setup_version="1.1.0">
         <sequence>
             <module name="Magento_Theme"/>
             <module name="Magento_Catalog"/>

--- a/view/adminhtml/ui_component/cms_page_form.xml
+++ b/view/adminhtml/ui_component/cms_page_form.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <fieldset name="search_engine_optimisation">
+        <field name="global_identifier">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="visible" xsi:type="boolean">true</item>
+                    <item name="label" xsi:type="string" translate="true">Global Identifier for HrefLang</item>
+                    <item name="formElement" xsi:type="string">input</item>
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="source" xsi:type="string">page</item>
+                    <item name="dataScope" xsi:type="string">global_identifier</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">false</rule>
+                    <rule name="identifier" xsi:type="boolean">true</rule>
+                </validation>
+            </settings>
+        </field>
+    </fieldset>
+</form>

--- a/view/adminhtml/ui_component/cms_page_listing.xml
+++ b/view/adminhtml/ui_component/cms_page_listing.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <columns name="cms_page_columns">
+        <column name="global_identifier">
+            <settings>
+                <filter>text</filter>
+                <editor>
+                    <validation>
+                        <rule name="validate-identifier" xsi:type="boolean">true</rule>
+                    </validation>
+                    <editorType>text</editorType>
+                </editor>
+                <label translate="true">Global Identifier</label>
+            </settings>
+        </column>
+    </columns>
+</listing>


### PR DESCRIPTION
Also add configuration option to define locale for hreflang tags (in case someone uses a more common locale like de_DE for the language pack, but would like a more specific locale like de_AT as it is a shop for AT)

 Introduce a "global identifier" field for CMS pages which is used to connect CMS pages of different stores with each other if identifiers differ

